### PR TITLE
feat:新增getMacAddress和hasNotch接口

### DIFF
--- a/harmony/device_info/src/main/ets/RNDeviceInfoModule.ts
+++ b/harmony/device_info/src/main/ets/RNDeviceInfoModule.ts
@@ -44,6 +44,7 @@ import { inputDevice } from '@kit.InputKit';
 import power from '@ohos.power';
 import Logger from './Logger';
 import screenLock from '@ohos.screenLock';
+import { display } from '@kit.ArkUI'
 
 const abiList32 = ["armeabi", "win_x86", "win_arm"];
 const abiList64 = ["arm64 v8", "Intel x86-64h Haswell", "arm64-v8a", "armeabi-v7a", "win_x64"];
@@ -414,6 +415,11 @@ export class RNDeviceInfoModule extends TurboModule implements TM.RNDeviceInfo.S
         return result;
     }
 
+    async getMacAddress():Promise<string> {
+        let linkInfo=await wifiManager.getLinkedInfo();
+        return linkInfo.macAddress
+    }
+
     getManufacturer(): Promise<string> {
         return new Promise<string>((resolve, reject) => {
             resolve(this.getManufacturerSync());
@@ -618,6 +624,18 @@ export class RNDeviceInfoModule extends TurboModule implements TM.RNDeviceInfo.S
 
     hasHmsSync(): boolean {
         return true;
+    }
+
+    async hasNotch(): Promise<boolean> {
+        let displayClass: display.Display = display.getDefaultDisplaySync();
+        if (!!!displayClass) {
+            return false
+        }
+        let result: display.CutoutInfo = await displayClass.getCutoutInfo();
+        if (result && result.boundingRects && result.boundingRects.length > 0) {
+            return true;
+        }
+        return false
     }
 
     isAirplaneMode(): Promise<boolean> {


### PR DESCRIPTION
# Summary

*  :新增getMacAddress和hasNotch接口
    Close : [新增getMacAddress和hasNotch接口 #32](https://github.com/react-native-oh-library/react-native-device-info/issues/32)。

## Test Plan
![image](https://github.com/user-attachments/assets/8a117d5f-fc83-4a37-9726-ef2ab8d0fa15)
![image](https://github.com/user-attachments/assets/f6fc22de-873f-4c36-9ba6-71b515b0d5fb)

## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [X] 已经更新了文档
- [ ] 更新了 JS/TS 代码