### PR TITLE
chore:修改使用react-native-device-info引入方式接口不返回数据问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,7 @@
   "name": "@react-native-oh-tpl/react-native-device-info",
   "version": "11.1.0-0.0.2",
   "description": "Get device information using react-native",
-  "react-native": "src/index.ts",
-  "types": "lib/typescript/index.d.ts",
-  "main": "lib/commonjs/index.js",
-  "module": "lib/module/index.js",
-  "source": "src/index.ts",
+  "main": "src/RNDeviceInfo.ts",
   "files": [
     "__tests__/",
     "/harmony",


### PR DESCRIPTION
# Summary

*  修改使用react-native-device-info引入方式接口不返回数据问题
    Close : [修改使用react-native-device-info引入方式接口不返回数据问题 #37](https://github.com/react-native-oh-library/react-native-device-info/issues/37)。

## Test Plan

![image](https://github.com/user-attachments/assets/1aeb93fa-8db8-4493-89f6-9b99fd52aa2a)


## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [ ] 更新了 JS/TS 代码